### PR TITLE
Update and cleanup

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -3,7 +3,7 @@ name = "base-x-neon"
 version = "0.1.0"
 dependencies = [
  "base-x 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "neon 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,35 +13,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cslice"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gcc"
-version = "0.3.26"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "neon"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "neon-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cslice 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "neon-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "neon-sys"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cslice 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum base-x 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c1bdfe01f4cba990e6c92254d603479b25f6ee6637f27a436e1d96e39c0dbd35"
-"checksum cslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8baf4a5864abdaebaa3010482359145b9d23fb110767a0beccb5a25e338fbe1"
-"checksum gcc 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3337bf4deec8dd33c331a62b59708f5b438779b8089b1888d56976ac2c325d3e"
-"checksum neon 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bf01eff88a04becd71f0dbc33654a71a18766fb5afe99bf5f047b15492b0224b"
-"checksum neon-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7c0a0002fc3b07321da6a45e588be5120b22c526cd380eddb0918f073e105dc0"
+"checksum cslice 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "878f29b18696f011e295fb80fd674f4fd7d9092f650bd3831db52dcb555cb441"
+"checksum gcc 0.3.43 (registry+https://github.com/rust-lang/crates.io-index)" = "c07c758b972368e703a562686adb39125707cc1ef3399da8c019fc6c2498a75d"
+"checksum neon 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3ac98e6946843ae8b6655aa1c20fce2ac9793663d9768a4b357b552888d16f"
+"checksum neon-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e90324af05f48b61f2986b4bb38d57ed363bd05272225b0c59674ea220693598"

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -3,48 +3,51 @@ extern crate neon;
 extern crate base_x;
 
 use neon::vm;
-use neon::vm::{Call, JsResult};
-use neon::js::{JsString};
+use neon::vm::{Call, JsResult, Lock};
+use neon::js::JsString;
 use neon::js::binary::JsBuffer;
 use neon::mem::Handle;
 
 fn encode(call: Call) -> JsResult<JsString> {
-  let scope = call.scope;
-  let alphabet: Handle<JsString> = try!(try!(call.arguments.require(scope, 0)).check::<JsString>());
-  let alphabet: &str = &alphabet.value()[..];
-  let buffer: Handle<JsBuffer> = try!(try!(call.arguments.require(scope, 1)).check::<JsBuffer>());
-  let result = vm::lock(buffer, |data| {
-    let mut vec:Vec<u8> = Vec::with_capacity(data.len());
-    let pointer = data.as_ptr();
-    for i in 0..data.len() {
-      vec.push(unsafe { *pointer.offset(i as isize) as u8 });
-    }
-    base_x::encode(alphabet, &vec)
-  });
-  Ok(JsString::new(scope, &result).unwrap())
+    let scope = call.scope;
+    let alphabet: Handle<JsString> = try!(try!(call.arguments.require(scope, 0))
+        .check::<JsString>());
+    let alphabet: &str = &alphabet.value()[..];
+    let mut buffer: Handle<JsBuffer> = try!(try!(call.arguments.require(scope, 1))
+        .check::<JsBuffer>());
+    let result = buffer.grab(|data| {
+        let mut vec: Vec<u8> = Vec::with_capacity(data.len());
+        let pointer = data.as_ptr();
+        for i in 0..data.len() {
+            vec.push(unsafe { *pointer.offset(i as isize) as u8 });
+        }
+        base_x::encode(alphabet, &vec)
+    });
+    Ok(JsString::new(scope, &result).unwrap())
 }
 
 fn decode(call: Call) -> JsResult<JsBuffer> {
-  let scope = call.scope;
-  let alphabet: Handle<JsString> = try!(try!(call.arguments.require(scope, 0)).check::<JsString>());
-  let alphabet: &str = &alphabet.value()[..];
-  let input: Handle<JsString> = try!(try!(call.arguments.require(scope, 1)).check::<JsString>());
-  let input =  &input.value();
-  let result = base_x::decode(alphabet, input).unwrap();
-  let buffer = try!(JsBuffer::new(scope, result.len() as u32));
-  vm::lock(buffer, |data| {
-    let mut b = data;
-    let mut i = 0;
-    for x in & result {
-      b[i] = *x as u8;
-      i=i+1;
-    }
-  });
-  Ok(buffer)
+    let scope = call.scope;
+    let alphabet: Handle<JsString> = try!(try!(call.arguments.require(scope, 0))
+        .check::<JsString>());
+    let alphabet: &str = &alphabet.value()[..];
+    let input: Handle<JsString> = try!(try!(call.arguments.require(scope, 1)).check::<JsString>());
+    let input = &input.value();
+    let result = base_x::decode(alphabet, input).unwrap();
+    let mut buffer = try!(JsBuffer::new(scope, result.len() as u32));
+    buffer.grab(|mut data| {
+        // let mut b = data;
+        let mut i = 0;
+        for x in &result {
+            data[i] = *x as u8;
+            i = i + 1;
+        }
+    });
+    Ok(buffer)
 }
 
 register_module!(m, {
-  try!(m.export("encode", encode));
-  try!(m.export("decode", decode));
-  Ok(())
+    try!(m.export("encode", encode));
+    try!(m.export("decode", decode));
+    Ok(())
 });

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate neon;
 extern crate base_x;
 
-use neon::vm;
 use neon::vm::{Call, JsResult, Lock};
 use neon::js::JsString;
 use neon::js::binary::JsBuffer;
@@ -10,44 +9,49 @@ use neon::mem::Handle;
 
 fn encode(call: Call) -> JsResult<JsString> {
     let scope = call.scope;
-    let alphabet: Handle<JsString> = try!(try!(call.arguments.require(scope, 0))
-        .check::<JsString>());
-    let alphabet: &str = &alphabet.value()[..];
-    let mut buffer: Handle<JsBuffer> = try!(try!(call.arguments.require(scope, 1))
-        .check::<JsBuffer>());
-    let result = buffer.grab(|data| {
-        let mut vec: Vec<u8> = Vec::with_capacity(data.len());
-        let pointer = data.as_ptr();
-        for i in 0..data.len() {
-            vec.push(unsafe { *pointer.offset(i as isize) as u8 });
-        }
-        base_x::encode(alphabet, &vec)
-    });
+
+    let alphabet = call.arguments
+        .require(scope, 0)?
+        .check::<JsString>()?
+        .value();
+
+    let mut buffer = call.arguments
+        .require(scope, 1)?
+        .check::<JsBuffer>()?;
+
+    let result = buffer.grab(|data| base_x::encode(alphabet.as_bytes(), data.as_slice()));
+
     Ok(JsString::new(scope, &result).unwrap())
 }
 
 fn decode(call: Call) -> JsResult<JsBuffer> {
     let scope = call.scope;
-    let alphabet: Handle<JsString> = try!(try!(call.arguments.require(scope, 0))
-        .check::<JsString>());
-    let alphabet: &str = &alphabet.value()[..];
-    let input: Handle<JsString> = try!(try!(call.arguments.require(scope, 1)).check::<JsString>());
-    let input = &input.value();
-    let result = base_x::decode(alphabet, input).unwrap();
-    let mut buffer = try!(JsBuffer::new(scope, result.len() as u32));
+
+    let alphabet = call.arguments
+        .require(scope, 0)?
+        .check::<JsString>()?
+        .value();
+
+    let input = call.arguments
+        .require(scope, 1)?
+        .check::<JsString>()?
+        .value();
+
+    let mut result = base_x::decode(alphabet.as_bytes(), &input).unwrap();
+    let mut buffer = JsBuffer::new(scope, result.len() as u32)?;
     buffer.grab(|mut data| {
-        // let mut b = data;
-        let mut i = 0;
-        for x in &result {
-            data[i] = *x as u8;
-            i = i + 1;
+        let mut slice = data.as_mut_slice();
+        for i in 0..result.len() {
+            slice[i] = result[i];
         }
     });
+
     Ok(buffer)
 }
 
 register_module!(m, {
-    try!(m.export("encode", encode));
-    try!(m.export("decode", decode));
+    m.export("encode", encode)?;
+    m.export("decode", decode)?;
+
     Ok(())
 });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "standard": "standard",
     "test": "npm run unit && npm run standard",
     "unit": "tape test/*.js",
-    "install": "neon build"
+    "install": "neon build",
+    "bench": "node ./benchmark/index.js"
   },
   "devDependencies": {
     "standard": "^6.0.8",


### PR DESCRIPTION
- Update rust deps
- Cleanup rust code to avoid unsafe code and additional overhead

bench before
```
base-x-native (master) ✗ node benchmark/

Seed: aabe04df97f2d26055ced6ba8ca35e75
  2 tests completed.

  rust_encode x 98,869 ops/sec ±1.28% (9 runs sampled)
  js_encode   x 96,920 ops/sec ±1.95% (8 runs sampled)

  2 tests completed.

  js_decode   x 217,634 ops/sec ±0.92% (8 runs sampled)
  rust_decode x 106,053 ops/sec ±11.27% (9 runs sampled)
```

after
```
base-x-native (update-deps) ✔ node benchmark

Seed: db76c819a61743b64cb4260afc56552d
  2 tests completed.

  rust_encode x 75,889 ops/sec ±1.82% (9 runs sampled)
  js_encode   x 58,472 ops/sec ±3.17% (9 runs sampled)

  2 tests completed.

  js_decode   x  78,575 ops/sec ±26.41% (8 runs sampled)
  rust_decode x 122,758 ops/sec ±3.01% (9 runs sampled)
```